### PR TITLE
New resource: Rust tag in blog SysInCloud added in pt_BR.md

### DIFF
--- a/pt_BR.md
+++ b/pt_BR.md
@@ -4,3 +4,4 @@
 
 * [Rust on the Rocks](http://rustontherocks.org/)
 * [Estruturas de dados e (um pouco sobre) Ownership](https://github.com/bltavares/presentations/blob/gh-pages/rust-tipos-e-ownership/rust-tipos-e-ownership.org)
+* [Textos diversos sobre Rust no blog SysInCloud](http://www.sysincloud.it/tag/rust/)


### PR DESCRIPTION
I added Rust tag from my blog (http://www.sysincloud.it) to portuguese Brasil.