### PR TITLE
Add Japanese translation of Rust by Example

### DIFF
--- a/ja_JP.md
+++ b/ja_JP.md
@@ -1,5 +1,10 @@
 # rust-learning
 
-## 日本語 (Japanese)
+## 日本語 | Japanese
 
-* [プログラミング言語Rust](http://rust-lang-ja.github.io/the-rust-programming-language-ja/1.6/book/) (Translation of the official The Rust Programming Language book)
+- [**プログラミング言語Rust**](http://rust-lang-ja.github.io/the-rust-programming-language-ja/1.6/book/)
+  * 公式ドキュメント [The Rust Programming Language](https://doc.rust-lang.org/book/) の和訳
+  * Japanese translation of the official book: The Rust Programming Language
+- [**Rust by Example**](http://rust-lang-ja.org/rust-by-example/)
+  * [Rust by Example](http://rustbyexample.com/) の和訳
+  * Japanese translation of Rust by Example


### PR DESCRIPTION
- Add a link to [a Japanese translation of Rust by Example](http://rust-lang-ja.org/rust-by-example/)
- Reorganize the descriptions about [the Japanese translation of The Rust Programming Language](http://rust-lang-ja.github.io/the-rust-programming-language-ja/1.6/book/)