### PR TITLE
Remove falsely official style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ You can watch Rust's meetups at [air.mozilla](https://air.mozilla.org/channels/r
 
 ## Best Practices/Style Guides
 
-* [official] [WIP] [Rust Guidelines](https://github.com/rust-lang/rust/tree/master/src/doc/style)
 * [Rust Design Patterns](https://github.com/nrc/patterns) - [Nick Cameron][]
 * [Error Handling in Rust](http://blog.burntsushi.net/rust-error-handling/) - [Andrew Gallant][]
 * [Reading Rust Function Signatures](http://hoverbear.org/2015/07/10/reading-rust-function-signatures/) - [Andrew Hobden][]


### PR DESCRIPTION
The documents that the link referenced are no longer present in the repository.
Per the commit message that removed them, the documents were never quite
official either. See: rust-lang/rust@00d4a43d84d5979332dbbbc4329211b007f7fe45