### PR TITLE
Add link to Mozilla Hispano blog post

### DIFF
--- a/es_ES.md
+++ b/es_ES.md
@@ -3,3 +3,4 @@
 ## Spanish
 
 * [Translation of the official The Rust Programming Language book](https://goyox86.github.io/elpr)
+* [Aprendiendo Rust por primera vez](https://www.mozilla-hispano.org/aprendiendo-rust-por-primera-vez/)


### PR DESCRIPTION
Link to an introduction to Rust in Mozilla Hispano