### PR TITLE
Fix #42 : Add Pennsylvania & Northwestern classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,11 @@ of interest if you're running a workshop on Rust.
 * Florian Gilcher's [mailbox tutorial](https://github.com/skade/mailbox) takes Hello World to a whole new concurrent and networked level
 * Carol Nichols' [Intro to Rust](https://github.com/carols10cents/intro-to-rust) that presents the guessing game and ownership in a similar manner as the book
 
+A few universities have had classes about Rust. Here are links to their public resources. 
+
+* University of Pennsylvania [CIS 198: Rust Programming](http://cis198-2016s.github.io/), Spring 2016, Rust 1.6. Slides linked from Schedule page.
+* Northwestern University [EECS 3/495: Concurrent Programming in Rust](http://users.eecs.northwestern.edu/~jesse/course/eecs395rust-wi16/), Winter 2016, Rust 1.6. Slides linked from Schedule page.
+
 <!-- Rustaceans -->
 [Aaron Turon]: https://github.com/aturon
 [Alex Crichton]: https://github.com/alexcrichton


### PR DESCRIPTION
Tracked down current link for the Northwestern one; both have slides and code/homework assignments.