### PR TITLE
Updated Documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A bunch of links to blog posts, articles, videos, etc for learning Rust. Feel fr
 
 *Do you need to be convinced that Rust worth learning?* Let us show you the [True Nature of the Force](https://brson.github.io/fireflowers/)
 
-The main documentation is always the best beginning, so if you haven't read yet, start by reading [Rust docs](http://www.rust-lang.org/). You also have ebook versions of the doc [here](http://killercup.github.io/trpl-ebook/) and [there](https://github.com/lise-henry/books/).
+The main documentation is always the best beginning, so if you haven't read yet, start by reading [Rust docs](https://www.rust-lang.org/en-US/documentation.html). You also have ebook versions of the doc [here](http://killercup.github.io/trpl-ebook/) and [there](https://github.com/lise-henry/books/).
 
 ### Tags meanings
 


### PR DESCRIPTION
The current url directs to the main page of rust rather than the doucmentation.