### PR TITLE
Adding reference for Erlang and rust comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The main documentation is always the best beginning, so if you haven't read yet,
 | Python          | <ul><li>[Rust for Python Programmers](http://lucumr.pocoo.org/2015/5/27/rust-for-pythonistas/) - Armin Ronacher</li><li>[py2rs](https://github.com/rochacbruno/py2rs) - Bruno Rocha</li></ul> |
 | Ruby            | <ul><li>[Rust for Rubyists](http://www.rustforrubyists.com/) - [Steve Klabnik][]</li></ul> |
 | Swift           | <ul><li>[A Swift guide to Rust](http://faq.sealedabstract.com/rust/) - sealedabstract</li><li>[Rust and Swift](http://www.chriskrycho.com/rust-and-swift.html) - [Chris Krycho][]</li></ul> |
-| Erlang           | <ul><li>[A Comparison between erlang and rust starting from language semantics to runtime features, performance etc..](https://www.infoq.com/articles/rust-erlang-comparison) - [Krishna Kumar Thokala][]</li></ul> |
+| Erlang           | <ul><li>[A Comparison between erlang and rust starting from language semantics to runtime features, performance etc..](https://www.infoq.com/articles/rust-erlang-comparison) - [Krishna Kumar Thokala]</li></ul> |
 
 ## Applications / Libraries / Tools
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ The main documentation is always the best beginning, so if you haven't read yet,
 | Python          | <ul><li>[Rust for Python Programmers](http://lucumr.pocoo.org/2015/5/27/rust-for-pythonistas/) - Armin Ronacher</li><li>[py2rs](https://github.com/rochacbruno/py2rs) - Bruno Rocha</li></ul> |
 | Ruby            | <ul><li>[Rust for Rubyists](http://www.rustforrubyists.com/) - [Steve Klabnik][]</li></ul> |
 | Swift           | <ul><li>[A Swift guide to Rust](http://faq.sealedabstract.com/rust/) - sealedabstract</li><li>[Rust and Swift](http://www.chriskrycho.com/rust-and-swift.html) - [Chris Krycho][]</li></ul> |
+| Erlang           | <ul><li>[A Comparison between erlang and rust starting from language semantics to runtime features, performance etc..](https://www.infoq.com/articles/rust-erlang-comparison) - [Krishna Kumar Thokala](https://twitter.com/krishnakumart36)</li></ul> |
 
 ## Applications / Libraries / Tools
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The main documentation is always the best beginning, so if you haven't read yet,
 | Python          | <ul><li>[Rust for Python Programmers](http://lucumr.pocoo.org/2015/5/27/rust-for-pythonistas/) - Armin Ronacher</li><li>[py2rs](https://github.com/rochacbruno/py2rs) - Bruno Rocha</li></ul> |
 | Ruby            | <ul><li>[Rust for Rubyists](http://www.rustforrubyists.com/) - [Steve Klabnik][]</li></ul> |
 | Swift           | <ul><li>[A Swift guide to Rust](http://faq.sealedabstract.com/rust/) - sealedabstract</li><li>[Rust and Swift](http://www.chriskrycho.com/rust-and-swift.html) - [Chris Krycho][]</li></ul> |
-| Erlang           | <ul><li>[A Comparison between erlang and rust starting from language semantics to runtime features, performance etc..](https://www.infoq.com/articles/rust-erlang-comparison) - [Krishna Kumar Thokala](https://twitter.com/krishnakumart36)</li></ul> |
+| Erlang           | <ul><li>[A Comparison between erlang and rust starting from language semantics to runtime features, performance etc..](https://www.infoq.com/articles/rust-erlang-comparison) - [Krishna Kumar Thokala][]</li></ul> |
 
 ## Applications / Libraries / Tools
 


### PR DESCRIPTION
source - https://www.infoq.com/articles/rust-erlang-comparison

<!-- Thanks for contributing to rust-learning 😊 -->

<!-- Describe shortly why it should be added to `rust-learning` -->
It is always skeptical for developers to pick a new language and would be trying to understand relatively with what they have already mastered. This articles aims at narrowing the understanding gap between erlang and rustlang by drawing a close analogy that allows both communities try out each others ways and understand them better.
<!-- Mention if you are the resource(s) author -->
Yes, I am the resource author.
