### PR TITLE
Add link in KR page

### DIFF
--- a/ko_KR.md
+++ b/ko_KR.md
@@ -2,5 +2,6 @@
 
 ## Korean
 
-* [Translation of the official The Rust Programming Language book](https://github.com/rust-kr/doc.rust-kr.org)
+* [Translation of the official The Rust Programming Language book](https://github.com/rust-kr/doc.rust-kr.org) (현재 중단)
 * [Rust in Detail: 확장 가능한 채팅 서비스 만들기 1/2](http://blog.naver.com/futurewave01/220539095123)
+* [러스트 프로그래밍 언어 - 2판](https://github.com/rinthel/rust-lang-book-ko)


### PR DESCRIPTION
<!-- Describe shortly why it should be added to `rust-learning` -->
I added link of rust-book KR translation project which is most active currently.
