### PR TITLE
Add Rust in Motion video course

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The main documentation is always the best beginning, so if you haven't read yet,
 * [Tensor Programming Tutorials](https://www.youtube.com/watch?v=EYqceb2AnkU&list=PLJbE2Yu2zumDF6BX6_RdPisRVHgzV02NW) - Tensor Programming
 * [Hello Rust!](https://www.youtube.com/channel/UCZ_EWaQZCZuGGfnuqUoHujw) - Matthias Endler
 * [YouCodeThings](https://www.youtube.com/channel/UC0yCXVwW6FdDQGYA-3OWXxw/) - Andrew Jakubowicz
+* :star: :soon: [Rust in Motion](https://www.manning.com/livevideo/rust-in-motion?a_aid=cnichols&a_bid=6a993c2e) - Video course by Carol Nichols and Jake Goulding
 
 ### Presentations
 


### PR DESCRIPTION
Hi! I'm one of the resource authors, @shepmaster is the other :) We're working on a video course for Manning called Rust in Motion, and it's currently in early access so I added the :soon: marker.

Also, full disclosure, I used an affiliate link. If you don't want affiliate links in here, that's totally fine! Let me know and I will edit to remove those parameters :)
