### PR TITLE
Update README.md (Fix links for TRPL 1st, 2nd).

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The main documentation is always the best beginning, so if you haven't read yet,
 * :star: [The Rust Programming Language 1st edition](https://doc.rust-lang.org/1.30.0/book/first-edition/) - [repo](https://github.com/rust-lang/book/tree/master/first-edition)
 * :star: [The Rust Programming Language 2nd edition](https://doc.rust-lang.org/1.30.0/book/second-edition/) - [repo](https://github.com/rust-lang/book/tree/master/second-edition) ([Paper edition](https://www.nostarch.com/Rust))
 * :star: [The Rust Programming Language 2018 edition](https://doc.rust-lang.org/1.30.0/book/2018-edition/) - [repo](https://github.com/rust-lang/book/tree/master/2018-edition)
+* :star: [The Rust Programming Language current version](https://doc.rust-lang.org/stable/book/) - [repo](https://github.com/rust-lang/book)
 * :star: [The Rust Reference](https://doc.rust-lang.org/stable/reference/) - [repo](https://github.com/rust-lang-nursery/reference)
 * :star: [The Rustonomicon - The Dark Arts of Advanced and Unsafe Rust Programming](https://doc.rust-lang.org/stable/nomicon/) - [repo](https://github.com/rust-lang-nursery/nomicon)
 * :star: [The Unstable Book](https://doc.rust-lang.org/stable/unstable-book/) - [repo](https://github.com/rust-lang/rust/tree/master/src/doc/unstable-book)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The main documentation is always the best beginning, so if you haven't read yet,
 
 * :star: [The Rust Programming Language 1st edition](https://doc.rust-lang.org/1.30.0/book/first-edition/) - [repo](https://github.com/rust-lang/book/tree/master/first-edition)
 * :star: [The Rust Programming Language 2nd edition](https://doc.rust-lang.org/1.30.0/book/second-edition/) - [repo](https://github.com/rust-lang/book/tree/master/second-edition) ([Paper edition](https://www.nostarch.com/Rust))
+* :star: [The Rust Programming Language 2018 edition](https://doc.rust-lang.org/1.30.0/book/2018-edition/) - [repo](https://github.com/rust-lang/book/tree/master/2018-edition)
 * :star: [The Rust Reference](https://doc.rust-lang.org/stable/reference/) - [repo](https://github.com/rust-lang-nursery/reference)
 * :star: [The Rustonomicon - The Dark Arts of Advanced and Unsafe Rust Programming](https://doc.rust-lang.org/stable/nomicon/) - [repo](https://github.com/rust-lang-nursery/nomicon)
 * :star: [The Unstable Book](https://doc.rust-lang.org/stable/unstable-book/) - [repo](https://github.com/rust-lang/rust/tree/master/src/doc/unstable-book)

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ The main documentation is always the best beginning, so if you haven't read yet,
 
 ## Books
 
-* :star: [The Rust Programming Language 1st edition](https://doc.rust-lang.org/stable/book/first-edition/) - [repo](https://github.com/rust-lang/book/tree/master/first-edition)
-* :star: [The Rust Programming Language 2nd edition](https://doc.rust-lang.org/stable/book/second-edition/) - [repo](https://github.com/rust-lang/book/tree/master/second-edition) ([Paper edition](https://www.nostarch.com/Rust))
+* :star: [The Rust Programming Language 1st edition](https://doc.rust-lang.org/1.30.0/book/first-edition/) - [repo](https://github.com/rust-lang/book/tree/master/first-edition)
+* :star: [The Rust Programming Language 2nd edition](https://doc.rust-lang.org/1.30.0/book/second-edition/) - [repo](https://github.com/rust-lang/book/tree/master/second-edition) ([Paper edition](https://www.nostarch.com/Rust))
 * :star: [The Rust Reference](https://doc.rust-lang.org/stable/reference/) - [repo](https://github.com/rust-lang-nursery/reference)
 * :star: [The Rustonomicon - The Dark Arts of Advanced and Unsafe Rust Programming](https://doc.rust-lang.org/stable/nomicon/) - [repo](https://github.com/rust-lang-nursery/nomicon)
 * :star: [The Unstable Book](https://doc.rust-lang.org/stable/unstable-book/) - [repo](https://github.com/rust-lang/rust/tree/master/src/doc/unstable-book)


### PR DESCRIPTION
Fix links for "The Rust Programming Language 1st edition" and "The Rust Programming Language 2nd edition".

With rust 2018 the URL's have changed.
