### PR TITLE
Removed J M Archer's playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ The main documentation is always the best beginning, so if you haven't read it y
 
 * :star: [Rust and the Future of Systems Programming](https://www.youtube.com/playlist?list=PLo3w8EB99pqJ74XIGe72c9hBZWz9Y16cY) - Mozilla
 * [RustFest Zürich 2017](https://www.youtube.com/watch?v=jywiVWKm1TI&list=PL85XCvVPmGQj9mqbJizw-zi-EhcpS5jTP)
-* [J M Archer Tutorials](https://www.youtube.com/playlist?list=PLTOeCUgrkpMNEHx6j0vCH0cuyAIVZadnc) - J M Archer
 * [ABitWiseGuy Tutorials](https://www.youtube.com/watch?v=y-ks-_VDkiA&list=PL0Fqs05rod8D80WKBCeT326CT8vcAm_N9) - ABitWiseGuy
 * [dcode Tutorials](https://www.youtube.com/watch?v=vOMJlQ5B-M0&list=PLVvjrrRCBy2JSHf9tGxGKJ-bYAN_uDCUL) - dcode
 * [Tensor Programming Tutorials](https://www.youtube.com/watch?v=EYqceb2AnkU&list=PLJbE2Yu2zumDF6BX6_RdPisRVHgzV02NW) - Tensor Programming


### PR DESCRIPTION
<!-- Thanks for contributing to rust-learning 😊 -->

<!-- Describe shortly why it should be added to `rust-learning` -->
The playlist and all of the channel's videos were deleted. The youtube channel's name also seems to be changed, leading me to believe that it has been discontinued.
<!-- Mention if you are the resource(s) author -->
