### PR TITLE
Fix markdown linter execution in GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       - name: Check links
         run: npx markdown-link-check -c .markdown-link-check-config.json README.md

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       - name: Lint markdown
         run: npx markdownlint-cli2 "*.md" "#MAINTAINERS.md"

--- a/README.md
+++ b/README.md
@@ -351,7 +351,6 @@ Can I use feature X? [caniuse.rs - Rust feature search](https://caniuse.rs/)
 * [Understanding Lifetime in Rust part 1](https://mobiarch.wordpress.com/2015/06/29/understanding-lifetime-in-rust-part-i/) | [part 2](https://mobiarch.wordpress.com/2015/07/08/understanding-lifetime-in-rust-part-ii-3/) - Bibhas Bhattacharya
 * [Rust Lifetimes](https://www.charlesetc.com/rust-lifetimes/) - Charles
 * [The Power of Lifetimes](http://pling.jondgoodwin.com/post/lifetimes/) - Jonathan Goodwin
-* [Understanding Lifetimes](https://rniczh.github.io/blog/lifetimes-intro/) - Hong-Sheng ‘Rnic‘ Zheng
 * [Understanding Rust Lifetimes](https://medium.com/nearprotocol/understanding-rust-lifetimes-e813bcd405fa) - Maksym Zavershynskyi
 * [Common Rust Lifetime Misconceptions](https://github.com/pretzelhammer/rust-blog/blob/master/posts/common-rust-lifetime-misconceptions.md) - kirill
 
@@ -521,10 +520,6 @@ of interest if you're running a workshop on Rust.
 * Florian Gilcher's [mailbox tutorial](https://github.com/skade/mailbox) takes Hello World to a whole new concurrent and networked level
 * Carol Nichols' [Intro to Rust](https://github.com/carols10cents/intro-to-rust) that presents the guessing game and ownership in a similar manner as the book
 * Jonathan Pallant's [Rust on the Raspberry Pi tutorial (using a Sense HAT)](https://github.com/thejpster/pi-workshop-rs)
-
-A few universities have had classes about Rust. Here are links to their public resources.
-
-* University of Pennsylvania [CIS 198: Rust Programming](https://www.cis.upenn.edu/~cis198/), Fall 2019, Rust 1.37.0. Slides linked from Schedule page. [Github](https://github.com/upenn-cis198)
 
 <!-- Rustaceans -->
 [Aaron Turon]: https://github.com/aturon

--- a/README.md
+++ b/README.md
@@ -529,27 +529,21 @@ of interest if you're running a workshop on Rust.
 [Andrew Hobden]: https://github.com/Hoverbear
 [Ben Ashford]: https://github.com/benashford
 [Brian Anderson]: https://github.com/brson
-[Carl Lerche]: https://github.com/carllerche
 [Carol Nichols]: https://github.com/carols10cents
 [Chris Krycho]: https://github.com/chriskrycho
 [Chris Morgan]: https://github.com/chris-morgan
 [Christoph Burgdorf]: https://github.com/cburgdorf
 [Daniel Keep]: https://github.com/DanielKeep
 [Dan Callahan]: https://github.com/callahad
-[Eduard Burtescu]: https://github.com/eddyb
 [Felix S Klock II]: https://github.com/pnkfelix
-[Gulshan Singh]: https://github.com/gsingh93
 [Herman J. Radtke III]: https://github.com/hjr3
-[Jakub Bukaj]: https://github.com/jakub-
 [Jeena Lee]: https://github.com/jeenalee
 [Jeremiah Peschka]: https://github.com/peschkaj
 [Jim Blandy]: https://github.com/jimblandy
 [Jorge Aparicio]: https://github.com/japaric
-[Josh Matthews]: https://github.com/jdm
 [Jonathan Turner]: https://github.com/jonathandturner
 [Llogiq]: https://github.com/llogiq
 [Luca Palmieri]: https://github.com/LukeMathWalker
-[Luqman Aden]: https://github.com/luqmana
 [Lloyd Chan]: https://github.com/lloydmeta
 [Huon Wilson]: https://github.com/huonw
 [Manish Goregaokar]: https://github.com/Manishearth
@@ -558,12 +552,8 @@ of interest if you're running a workshop on Rust.
 [Niko Matsakis]: https://github.com/nikomatsakis
 [Pascal Hertleif]: https://github.com/killercup
 [Patrick Walton]: https://github.com/pcwalton
-[Seo Sanghyeon]: https://github.com/sanxiyn
-[Simon Sapin]: https://github.com/SimonSapin
 [Steve Donovan]: https://github.com/stevedonovan
 [Steve Klabnik]: https://github.com/steveklabnik
-[Steven Fackler]: https://github.com/sfackler
-[Tetsuharu OHZEKI]: https://github.com/saneyuki
 [Tim McNamara]: https://github.com/timClicks
 [Yehuda Katz]: https://github.com/wycats
 [Dumindu Madunuwan]: https://github.com/dumindu

--- a/tr_TR.md
+++ b/tr_TR.md
@@ -3,5 +3,4 @@
 ## Türkçe
 
 * [Rust Programlama Diline Giriş - Video ](https://www.youtube.com/watch?v=x4KzewBQgRQ) - Cengiz Can (Istanbul Coders)
-* [Rust'a Giriş V1 - E-Kitap ](http://documents.tips/software/rusta-giris-v1.html) - Mahmut Bulut @vertexclique
 * [Rust Programlama Dili - E-Kitap ](https://www.gitbook.com/book/cngzhnp/rust-programlama-dili/) - Cengizhan Pasaoglu


### PR DESCRIPTION
**Problem**: "Cannot find module 'node:path'"
**Cause**: Current markdownlint version is not compatible with node10
**Measure**: use node16 explicitly

Also, fixed linter errors: remove not existing resources.

## BEFORE

![image](https://user-images.githubusercontent.com/5967447/187028744-81743bf8-1f1f-4b74-824b-0b7d2360a5dc.png)

## AFTER

![image](https://user-images.githubusercontent.com/5967447/187071111-d4923988-4ad0-45ab-b229-64990d74d016.png)
