### PR TITLE
Fix Rust API guidelines URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The main documentation is always the best beginning, so if you haven't read it y
 
 * :star: [Rust Design Patterns](https://github.com/nrc/patterns) - [Nick Cameron][]
 * :star: [Error Handling in Rust](http://blog.burntsushi.net/rust-error-handling/) - [Andrew Gallant][]
-* :star: [Rust API guidelines](https://github.com/rust-lang/rust-api-guidelines) - [Brian Anderson][]
+* :star: [Rust API guidelines](https://github.com/rust-lang/api-guidelines) - [Brian Anderson][]
 * [Design Patterns in Rust](https://github.com/fadeevab/design-patterns-rust) - [Alexander Fadeev][]
 * [Reading Rust Function Signatures](http://hoverbear.org/2015/07/10/reading-rust-function-signatures/) - [Ana Hoverbear][]
 * [Good Practices for Writing Rust Libraries](https://pascalhertleif.de/artikel/good-practices-for-writing-rust-libraries/) - [Pascal Hertleif][]


### PR DESCRIPTION
The repository may have been renamed, so the previous links was dead.

<!-- Thanks for contributing to rust-learning 😊 -->

<!-- Describe shortly why it should be added to `rust-learning` -->
<!-- Mention if you are the resource(s) author -->
