### PR TITLE
Add the cargo book

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The main documentation is always the best beginning, so if you haven't read it y
 * :star: [Rust Cookbook](https://rust-lang-nursery.github.io/rust-cookbook/) - [repo](https://github.com/rust-lang-nursery/rust-cookbook)
 * :star: [Why Rust?](https://www.oreilly.com/content/why-rust/) - [Jim Blandy][]
 * :star: [The Embedded Rust Book](https://rust-embedded.github.io/book/intro/index.html) - [repo](https://github.com/rust-embedded/book) - Rust Embedded WG
+* :star: [The Cargo Book](https://doc.rust-lang.org/stable/cargo/) - [repo](https://github.com/rust-lang/cargo/tree/master/src/doc)
 * [Rust-101](https://www.ralfj.de/projects/rust-101/main.html) - Ralf Jung
 * [Rust Essentials](https://www.packtpub.com/application-development/rust-essentials-second-edition) -  Ivo Balbaert
 * [Programming Rust](http://shop.oreilly.com/product/0636920040385.do) - [Jim Blandy][], Jason Orendorff


### PR DESCRIPTION
<!-- Thanks for contributing to rust-learning 😊 -->

Add the official cargo book.

<!-- Describe shortly why it should be added to `rust-learning` -->
<!-- Mention if you are the resource(s) author -->
