### PR TITLE
Fix authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ Can I use feature X? [caniuse.rs - Rust feature search](https://caniuse.rs/)
 * [How to pass a closure into a trait object](http://camjackson.net/post/rust-lang-how-to-pass-a-closure-into-a-trait-object) - Cam Jackson
 * [Practical differences between Rust closures and functions](https://ricardomartins.cc/2015/10/12/practical_differences_between_rust_closures_and_functions) - Ricardo Martins
 * :star: [How Rust Achieves Thread Safety](https://manishearth.github.io/blog/2015/05/30/how-rust-achieves-thread-safety/) - [Manish Goregaokar][]
-* [Understanding Closures in Rust](https://medium.com/swlh/understanding-closures-in-rust-21f286ed1759) - [Steve Donovan][]
-* [Why Rust Closures are (Somewhat) Hard](https://stevedonovan.github.io/rustifications/2018/08/18/rust-closures-are-hard.html) - Andrew Pritchard
+* [Understanding Closures in Rust](https://medium.com/swlh/understanding-closures-in-rust-21f286ed1759) - Andrew Pritchard
+* [Why Rust Closures are (Somewhat) Hard](https://stevedonovan.github.io/rustifications/2018/08/18/rust-closures-are-hard.html) - [Steve Donovan][]
 
 ### Documentation
 


### PR DESCRIPTION
Two of the authors were swapped

<!-- Thanks for contributing to rust-learning 😊 -->

<!-- Describe shortly why it should be added to `rust-learning` -->
<!-- Mention if you are the resource(s) author -->
